### PR TITLE
Isu0030 update requirements.txt so that it runa using python3.8

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -2,7 +2,11 @@
 
 This text document explains the setup of the Noisy-Atom portal. The Noisy Atom portal is a Django based web server serving up the NoisyAtom home page, blog and example project work.
 
-The portal is based on Python version 3.8. This may not be supported on your current version of Linux. To get access to all the features we need 3.8 on your local machine. For this I used the [Deadsnake PPA](https://github.com/deadsnakes) which holds a number of pre-compiled python versions for Ubuntu.
+Ubuntu 18.04 is the targeted platform. This should run on Ubuntu 20.xx as is but not tested thoroughly.
+
+## Setup Python 3.8
+The portal is based on Python version 3.8. This may not be supported on your current version of Linux. 
+To get access to all the features we need 3.8 on your local machine. For this I used the [Deadsnake PPA](https://github.com/deadsnakes) which holds a number of pre-compiled python versions for Ubuntu.
 
 You can follow this link and instructions, however to reduce context switching you can follow commands here:
 
@@ -11,6 +15,16 @@ You can follow this link and instructions, however to reduce context switching y
 /> sudo add-apt-repository ppa:deadsnakes/ppa
 /> sudo apt update
 /> sudo apt install python3.8
+```
+
+## Installing Non-default Linux Packages
+The portal uses **postgres** as it's backend database. For this the python package psycopg2 will be installed.
+However, this requires the installation of several Linux packages which may not be on your default system. You
+need to have libpq-dev, python-dev, and python3.8-dev python development libraries since there will be compiled python
+binaries dependent on header files being available. To do this:
+
+```bash
+    /> sudo apt-get install libpq-dev python-dev python3.8-dev
 ```
 
 ## Install virtualenv & virtualenvwrapper

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -27,11 +27,58 @@ binaries dependent on header files being available. To do this:
     /> sudo apt-get install libpq-dev python-dev python3.8-dev
 ```
 
+The **Pillow** python graphics package also requires the following **zlib** and **jpeg** libraries which also may not
+be part of your vanilla setup. Install the Linux zlib packages. To do this:
+
+```bash
+
+  /> sudo apt install libjpeg8-dev zlib1g-dev
+
+```
+
 ## Install virtualenv & virtualenvwrapper
 Detailed instructions are [here](http://virtualenvwrapper.readthedocs.org/en/latest/install.html)
 
 ```bash
 /> sudo pip install virtualenvwrapper
+    Collecting appdirs==1.4.0
+      Using cached appdirs-1.4.0-py2.py3-none-any.whl (11 kB)
+    Collecting Django==1.10.5
+      Using cached Django-1.10.5-py2.py3-none-any.whl (6.8 MB)
+    Collecting django-bootstrap4==0.0.4
+      Using cached django_bootstrap4-0.0.4-py3-none-any.whl
+    Collecting django-markdown-deux==1.0.5
+      Using cached django_markdown_deux-1.0.5-py3-none-any.whl
+    Collecting django-pagedown==0.1.3
+      Using cached django_pagedown-0.1.3-py3-none-any.whl
+    Collecting django-crispy-forms==1.6.1
+      Using cached django_crispy_forms-1.6.1-py2.py3-none-any.whl (103 kB)
+    Collecting gunicorn==19.6.0
+      Using cached gunicorn-19.6.0-py2.py3-none-any.whl (114 kB)
+    Collecting Markdown==2.6.9
+      Using cached Markdown-2.6.9-py3-none-any.whl
+    Collecting markdown2==2.3.4
+      Using cached markdown2-2.3.4-py3-none-any.whl
+    Collecting olefile==0.44
+      Using cached olefile-0.44-py3-none-any.whl
+    Collecting packaging==16.8
+      Using cached packaging-16.8-py2.py3-none-any.whl (23 kB)
+    Collecting Pillow==4.0.0
+      Using cached Pillow-4.0.0-cp38-cp38-linux_x86_64.whl
+    Collecting psycopg2==2.8
+      Using cached psycopg2-2.8-cp38-cp38-linux_x86_64.whl
+    Collecting pyparsing==2.2.0
+      Using cached pyparsing-2.2.0-py2.py3-none-any.whl (56 kB)
+    Collecting six==1.11.0
+      Using cached six-1.11.0-py2.py3-none-any.whl (10 kB)
+    Installing collected packages: six, pyparsing, olefile, markdown2, Django, psycopg2, Pillow, packaging, Markdown, gunicorn, django-pagedown, django-markdown-deux, django-crispy-forms, django-bootstrap4, appdirs
+    Successfully installed Django-1.10.5 Markdown-2.6.9 Pillow-4.0.0 appdirs-1.4.0 django-bootstrap4-0.0.4 django-crispy-forms-1.6.1 django-markdown-deux-1.0.5 django-pagedown-0.1.3 gunicorn-19.6.0 markdown2-2.3.4 olefile-0.44 packaging-16.8 psycopg2-2.8 pyparsing-2.2.0 six-1.11.0
+    WARNING: You are using pip version 21.1.2; however, version 22.0.3 is available.
+    You should consider upgrading via the '/home/<your-dir>/virtualenv/noisy-atom/bin/python -m pip install --upgrade pip' command.
+    />
+
+
+
 ```
 
 ## Setup a Virtual Environment

--- a/noisyatom/requirements.txt
+++ b/noisyatom/requirements.txt
@@ -10,6 +10,6 @@ markdown2==2.3.4
 olefile==0.44
 packaging==16.8
 Pillow==4.0.0
-psycopg2==2.7
+psycopg2==2.8
 pyparsing==2.2.0
 six==1.11.0


### PR DESCRIPTION
This pull request makes one change to the requirements.txt file so that it can be run with pip on a vanilla Linux Ubuntu 18.04 system.

There are changes to the README.md file to explain what packages need to be installed. But to stop context switching the required steps to test this out are:

### Prerequisites 
* A vanilla Ubuntu box running Ubuntu 18.04.
* Virtualenv and Virtualenv wrapper installed.
* Python 3.8.x installed

### Run Commands
Run the following commands to test out it works on your system:

```
/> sudo apt update
/> sudo apt-get install libpq-dev python-dev python3.8-dev
/> sudo apt install libjpeg8-dev zlib1g-dev
/> mkvirtualenv --python=/usr/bin/python3.8 noisy-atom
/> workon noisy-atom
/> git clone https://github.com/nherriot/noisy-atom-portal.git
/> cd ~/virtalenv/noisy-atom/noisy-atom-portal/noisyatom
/> pip install -r requirements.txt 
Collecting appdirs==1.4.4
  Using cached appdirs-1.4.4-py2.py3-none-any.whl (9.6 kB)
Collecting asgiref==3.5.0
  Using cached asgiref-3.5.0-py3-none-any.whl (22 kB)
Collecting beautifulsoup4==4.10.0
  Using cached beautifulsoup4-4.10.0-py3-none-any.whl (97 kB)
Collecting Django==3.2.11
  Using cached Django-3.2.11-py3-none-any.whl (7.9 MB)
Collecting django-bootstrap4==21.2
  Using cached django_bootstrap4-21.2-py3-none-any.whl (24 kB)
Collecting django-crispy-forms==1.14.0
  Using cached django_crispy_forms-1.14.0-py3-none-any.whl (133 kB)
Collecting django-markdown-deux==1.0.5
  Using cached django_markdown_deux-1.0.5-py3-none-any.whl
Collecting django-pagedown==2.2.1
  Using cached django_pagedown-2.2.1-py3-none-any.whl (92 kB)
Collecting django-utils-six==2.0
  Using cached django_utils_six-2.0-py3-none-any.whl (10 kB)
Collecting gunicorn==20.1.0
  Using cached gunicorn-20.1.0-py3-none-any.whl (79 kB)
Collecting importlib-metadata==4.10.1
  Using cached importlib_metadata-4.10.1-py3-none-any.whl (17 kB)
Collecting Markdown==3.3.6
  Using cached Markdown-3.3.6-py3-none-any.whl (97 kB)
Collecting markdown2==2.4.2
  Using cached markdown2-2.4.2-py2.py3-none-any.whl (34 kB)
Collecting olefile==0.46
  Using cached olefile-0.46-py2.py3-none-any.whl
Collecting packaging==21.3
  Using cached packaging-21.3-py3-none-any.whl (40 kB)
Collecting Pillow==9.0.1
...
...
Successfully installed.
/> 

```

You should find that all packages are successfully installed on your Ubuntu system.
