### PR TITLE
Updating pacakages to allow smooth deployment on MAC, Docker and Digi…

### DIFF
--- a/noisyatom/config/settings.py
+++ b/noisyatom/config/settings.py
@@ -16,7 +16,7 @@ import socket
 
 
 # This should be set to 'prod' or 'dev' otherwise it will fail to run any type of django server
-ENVIRONMENT: str = config("ENVIRONMENT", default="dev")
+ENVIRONMENT: str = config("ENVIRONMENT", default="prod")
 print(f"***** Environment is set as: {ENVIRONMENT} *****")
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -30,8 +30,6 @@ PROJECT_ROOT = os.path.join(BASE_DIR, 'noisyatom')
 SECRET_KEY = 'needs-to-change'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-# Add your own computer name to this list of 'gethostname()' functions to get
-# debug to true. Otherwise, this will build a 'production' settings file.
 if ENVIRONMENT == "dev":
     print("\n***** WARNING! This is a non-production build *****")
     DEBUG = True

--- a/noisyatom/requirements.txt
+++ b/noisyatom/requirements.txt
@@ -9,8 +9,8 @@ Markdown==2.6.9
 markdown2==2.3.4
 olefile==0.44
 packaging==16.8
-Pillow==4.0.0
-psycopg2==2.8
+Pillow==6.2.1
+psycopg2-binary==2.9.3
 pyparsing==2.2.0
 python-decouple==3.6
 pytz==2021.3


### PR DESCRIPTION
This fixes issue: https://github.com/nherriot/noisy-atom-portal/issues/49

For systems running on **brew** package management i.e. MAC.
Or when the portal is deployed to a container, or VM in the cloud it is better to:
1. Use pcops2 binary packages to remove the need to install python-dev pacakges and compiling on host.
2. To stop python version exceptions which happen on Pillow when using binary pacakges.

To test this pull request install changes to your python packages using pip:

```
   /> pip install -r requirements.txt 
Requirement already satisfied: appdirs==1.4.0 in /home/nherriot/virtualenv/noisy-atom/lib/python3.8/site-packages (from -r requirements.txt (line 1)) (1.4.0)
Requirement already satisfied: Django==2 in /home/nherriot/virtualenv/noisy-atom/lib/python3.8/site-packages (from -r requirements.txt (line 2)) (2.0)
Requirement already satisfied: django-bootstrap4==0.0.4 in /home/nherriot/virtualenv/noisy-atom/lib/python3.8/site-packages (from -r requirements.txt (line 3)) (0.0.4)
Requirement already satisfied: django-crispy-forms==1.6.1 in /home/nherriot/virtualenv/noisy-atom/lib/python3.8/site-packages (from -r requirements.txt (line 4)) (1.6.1)
Requirement already satisfied: django-markdown-deux==1.0.5 in /home/nherriot/virtualenv/noisy-atom/lib/python3.8/site-packages (from -r requirements.txt (line 5)) (1.0.5)
Requirement already satisfied: django-pagedown==0.1.3 in /home/nherriot/virtualenv/noisy-atom/lib/python3.8/site-packages (from -r requirements.txt (line 6)) (0.1.3)
Requirement already satisfied: gunicorn==19.6.0 in /home/nherriot/virtualenv/noisy-atom/lib/python3.8/site-packages (from -r requirements.txt (line 7)) (19.6.0)
Requirement already satisfied: Markdown==2.6.9 in /home/nherriot/virtualenv/noisy-atom/lib/python3.8/site-packages (from -r requirements.txt (line 8)) (2.6.9)
Requirement already satisfied: markdown2==2.3.4 in /home/nherriot/virtualenv/noisy-atom/lib/python3.8/site-packages (from -r requirements.txt (line 9)) (2.3.4)
Requirement already satisfied: olefile==0.44 in /home/nherriot/virtualenv/noisy-atom/lib/python3.8/site-packages (from -r requirements.txt (line 10)) (0.44)
Requirement already satisfied: packaging==16.8 in /home/nherriot/virtualenv/noisy-atom/lib/python3.8/site-packages (from -r requirements.txt (line 11)) (16.8)
Collecting Pillow==6.2.1
  Downloading Pillow-6.2.1-cp38-cp38-manylinux1_x86_64.whl (2.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.1/2.1 MB 10.7 MB/s eta 0:00:00
Collecting psycopg2-binary==2.9.3
  Using cached psycopg2_binary-2.9.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.0 MB)
Requirement already satisfied: pyparsing==2.2.0 in /home/nherriot/virtualenv/noisy-atom/lib/python3.8/site-packages (from -r requirements.txt (line 14)) (2.2.0)
Requirement already satisfied: python-decouple==3.6 in /home/nherriot/virtualenv/noisy-atom/lib/python3.8/site-packages (from -r requirements.txt (line 15)) (3.6)
Requirement already satisfied: pytz==2021.3 in /home/nherriot/virtualenv/noisy-atom/lib/python3.8/site-packages (from -r requirements.txt (line 16)) (2021.3)
Requirement already satisfied: six==1.11.0 in /home/nherriot/virtualenv/noisy-atom/lib/python3.8/site-packages (from -r requirements.txt (line 17)) (1.11.0)
Requirement already satisfied: sqlparse==0.4.2 in /home/nherriot/virtualenv/noisy-atom/lib/python3.8/site-packages (from -r requirements.txt (line 18)) (0.4.2)
Installing collected packages: psycopg2-binary, Pillow
  Attempting uninstall: Pillow
    Found existing installation: Pillow 4.0.0
    Uninstalling Pillow-4.0.0:
      Successfully uninstalled Pillow-4.0.0
Successfully installed Pillow-6.2.1 psycopg2-binary-2.9.3
WARNING: You are using pip version 22.0.4; however, version 22.1.2 is available.
You should consider upgrading via the '/home/nherriot/virtualenv/noisy-atom/bin/python -m pip install --upgrade pip' command.
```

Run the server in your dev environment:

```
/>   python manage.py runserver
***** Environment is set as: dev *****

***** WARNING! This is a non-production build *****
***** Environment is set as: dev *****

***** WARNING! This is a non-production build *****
Performing system checks...

System check identified no issues (0 silenced).
June 07, 2022 - 21:24:21
Django version 2.0, using settings 'config.settings'
Starting development server at http://127.0.0.1:8000/
Quit the server with CONTROL-C.
```

There is also a removal of incorrect comments in settings.py and a change to default settings to 'prod' when our .env file is missing. This just ensures that worst case scenario that a live system can never be mistakenly be launched in **dev** mode.

