### PR TITLE
48 get ansible scripts working with the noisy atom web site

### DIFF
--- a/noisyatom/config/settings.py
+++ b/noisyatom/config/settings.py
@@ -107,7 +107,7 @@ if ENVIRONMENT == "prod":
         '.noisyatom.tech',
         '.noisyatom.co.uk',
         '.104.236.14.123',
-        '134.209.21.58',
+        '167.99.92.82',
         '46.101.19.29',
     ]
 

--- a/noisyatom/config/settings.py
+++ b/noisyatom/config/settings.py
@@ -103,9 +103,11 @@ if ENVIRONMENT == "prod":
     ALLOWED_HOSTS = [
         'localhost',
         '127.0.0.1',
-        'noisyatom.com',
-        'noisyatom.co.uk',
-        '104.236.14.123',
+        '.noisyatom.com',
+        '.noisyatom.tech',
+        '.noisyatom.co.uk',
+        '.104.236.14.123',
+        '134.209.21.58',
         '46.101.19.29',
     ]
 


### PR DESCRIPTION
This pull request has to be done in conjunction with a pull request for the Ansible scripts that are contained within a different repo here: https://github.com/NoisyAtom/noisyAtom_config/pull/1

This pull request needs to be done with help to test. Please contact n.herriot and do with owner.
Please read through other pull request for all details of how to test.

This fixes issue: #48 

